### PR TITLE
Make web service templates use 10 second timeout consistently

### DIFF
--- a/Extensions/CoreTemplates/Magenic.Maqs.Composite.Template/Tests/appsettings.json
+++ b/Extensions/CoreTemplates/Magenic.Maqs.Composite.Template/Tests/appsettings.json
@@ -62,7 +62,7 @@
   },
   "WebServiceMaqs": {
     "WebServiceUri": "http://magenicautomation.azurewebsites.net",
-    "WebServiceTimeout": "1000",
+    "WebServiceTimeout": "10000",
     "UseProxy": "No",
     "ProxyAddress": "127.0.0.1:8080"
   }

--- a/Extensions/CoreTemplates/Magenic.Maqs.Webservice.Template/Tests/appsettings.json
+++ b/Extensions/CoreTemplates/Magenic.Maqs.Webservice.Template/Tests/appsettings.json
@@ -9,7 +9,7 @@
   },
   "WebServiceMaqs": {
     "WebServiceUri": "http://magenicautomation.azurewebsites.net",
-    "WebServiceTimeout": "1000",
+    "WebServiceTimeout": "10000",
     "UseProxy": "No",
     "ProxyAddress": "127.0.0.1:8080"
   }

--- a/Extensions/CoreTemplates/QATBaseTemplate.nuspec
+++ b/Extensions/CoreTemplates/QATBaseTemplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
 <metadata minClientVersion="3.6">
     <id>Magenic.Maqs.Templates</id>
-    <version>5.6.0</version>
+    <version>5.6.0.1</version>
     <title>MAQS Core Templates</title>
     <authors>Magenic</authors>
     <owners>Magenic</owners>

--- a/Extensions/CoreTemplates/QATBaseTemplate.nuspec
+++ b/Extensions/CoreTemplates/QATBaseTemplate.nuspec
@@ -15,6 +15,10 @@
     <summary>Templates for Magenic's automation framework. 
 This package includes templates for browser, mobile, web service, database, email, generic and composite test solutions.</summary>
     <releaseNotes>
+    5.6.0.1 - 2019/10/16
+      Template updates
+      - Make web service template timeouts consistent at 10 seconds
+      
     5.6.0 - 2019/10/10
       Bug fixes and minor enhancements
       - Logging improvements

--- a/Extensions/VisualStudioQatExtensionOss/ProjectTemplates/Magenic Test Core/QATCompositeTemplate/Tests/appsettings.json
+++ b/Extensions/VisualStudioQatExtensionOss/ProjectTemplates/Magenic Test Core/QATCompositeTemplate/Tests/appsettings.json
@@ -61,7 +61,7 @@
   },
   "WebServiceMaqs": {
     "WebServiceUri": "http://magenicautomation.azurewebsites.net",
-    "WebServiceTimeout": "1000",
+    "WebServiceTimeout": "10000",
     "UseProxy": "No",
     "ProxyAddress": "127.0.0.1:8080"
   }

--- a/Extensions/VisualStudioQatExtensionOss/ProjectTemplates/Magenic Test Core/QATWebserviceTemplate/Tests/appsettings.json
+++ b/Extensions/VisualStudioQatExtensionOss/ProjectTemplates/Magenic Test Core/QATWebserviceTemplate/Tests/appsettings.json
@@ -9,7 +9,7 @@
   },
   "WebServiceMaqs": {
     "WebServiceUri": "http://magenicautomation.azurewebsites.net",
-    "WebServiceTimeout": "1000",
+    "WebServiceTimeout": "10000",
     "UseProxy": "No",
     "ProxyAddress": "127.0.0.1:8080"
   }

--- a/Extensions/VisualStudioQatExtensionOss/ReleaseNotes.txt
+++ b/Extensions/VisualStudioQatExtensionOss/ReleaseNotes.txt
@@ -1,4 +1,8 @@
 MAQS Framework Release Notes:
+5.6.0.1 - 2019/10/16
+    Template updates
+    - Make web service template timeouts consistent at 10 seconds
+
 5.6.0 - 2019/10/10
     Bug fixes and minor enhancements
     - Logging improvements

--- a/Extensions/VisualStudioQatExtensionOss/source.extension.vsixmanifest
+++ b/Extensions/VisualStudioQatExtensionOss/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="7f8a17ec-cc72-413f-ae85-bbbbb77f2d1f" Version="5.6.0.3" Language="en-US" Publisher="Magenic" />
+        <Identity Id="7f8a17ec-cc72-413f-ae85-bbbbb77f2d1f" Version="5.6.0.4" Language="en-US" Publisher="Magenic" />
         <DisplayName>MAQS Framework</DisplayName>
         <Description xml:space="preserve">Magenic's automation quick start framework</Description>
         <MoreInfo>https://magenic.com/what-we-do/support-optimization/quality-assurance</MoreInfo>


### PR DESCRIPTION
Core templates were 1 sec while framework templates were 10
Addresses #56 