### PR TITLE
Address duplicate logging #69

### DIFF
--- a/Framework/NugetBuild/package.nuspec
+++ b/Framework/NugetBuild/package.nuspec
@@ -18,6 +18,8 @@
       - Have lazy element FindElement and FindElements return lazy element
       - Add Exists and ExistsNow checks to lazy element
       - Consolidate core lazy element and core lazy mobile element functionality
+      - Exclude more duplicate log entries
+      - Stop create multiple log files for NUnit tests
 
       5.6.0 - 2019/10/10
       Bug fixes and minor enhancements

--- a/Framework/NugetBuild/packageSpecFlow.nuspec
+++ b/Framework/NugetBuild/packageSpecFlow.nuspec
@@ -18,6 +18,8 @@
       - Have lazy element FindElement and FindElements return lazy element
       - Add Exists and ExistsNow checks to lazy element
       - Consolidate core lazy element and core lazy mobile element functionality
+      - Exclude more duplicate log entries
+      - Stop create multiple log files for NUnit tests
 
       5.6.0 - 2019/10/10
       Bug fixes and minor enhancements

--- a/Framework/SeleniumUnitTests/SeleniumNUnitTest.cs
+++ b/Framework/SeleniumUnitTests/SeleniumNUnitTest.cs
@@ -5,9 +5,16 @@
 // <summary>NUnit test the selenium framework</summary>
 //-----------------------------------------------------
 using Magenic.Maqs.BaseSeleniumTest;
+using Magenic.Maqs.BaseSeleniumTest.Extensions;
 using Magenic.Maqs.Utilities.Helper;
+using Magenic.Maqs.Utilities.Logging;
 using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.RegularExpressions;
 
 namespace SeleniumUnitTests
 {
@@ -26,6 +33,33 @@ namespace SeleniumUnitTests
         public void OpenBrowser()
         {
             this.WebDriver.Navigate().GoToUrl("https://www.google.com");
+        }
+
+        /// <summary>
+        /// Make sure we are not doing duplicate logging
+        /// </summary>
+        [Test]
+        [Category(TestCategories.NUnit)]
+        public void NoLogFileDuplication()
+        {
+            string badSelector = "BADNOPENOTGOOD";
+            this.Log.SetLoggingLevel(MessageType.INFORMATION);
+
+            this.WebDriver.SetWaitDriver(new WebDriverWait(new SystemClock(), WebDriver, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(100)));
+
+            try
+            {
+                this.WebDriver.Wait().UntilClickableElement(By.CssSelector(badSelector));
+                this.WebDriver.Wait().ForClickableElement(By.CssSelector(badSelector));
+            }
+            catch
+            {
+                string text = File.ReadAllText((this.Log as FileLogger).FilePath);
+                Assert.AreEqual(1, Regex.Matches(text, badSelector).Count);
+                return;
+            }
+
+            Assert.Fail("Test should not have found bad selector: " +  badSelector);
         }
     }
 }


### PR DESCRIPTION
Do a better job of finding dup messages
Stop creating a new test object (and related new log file) if one already exists.

#69 