### PR TITLE
Move database integration tests to be ran against a Dockerized Version of SQL Server

### DIFF
--- a/Docker/SqlServer/SeedData/MagenicAutomation/States.csv
+++ b/Docker/SqlServer/SeedData/MagenicAutomation/States.csv
@@ -1,0 +1,50 @@
+StateID,StateName,StateAbbreviation
+1,Alaska,AK
+2,Arizona,AZ
+3,Arkansas,AR
+4,California,CA
+5,Colorado,CO
+6,Connecticut,CT
+7,Delaware,DE
+8,Florida,FL
+9,Georgia,GA
+10,Hawaii,HI
+11,Idaho,ID
+12,Illinois,IL
+13,Indiana,IN
+14,Iowa,IA
+15,Kansas,KS
+16,Kentucky,KY
+17,Louisiana,LA
+18,Maine,ME
+19,Maryland,MD
+20,Massachusetts,MA
+21,Michigan,MI
+22,Minnesota,MN
+23,Mississippi,MS
+24,Missouri,MO
+25,Montana,MT
+26,Nebraska,NE
+27,Nevada,NV
+28,New Hampshire,NH
+29,New Jersey,NJ
+30,New Mexico,NM
+31,New York,NY
+32,North Carolina,NC
+33,North Dakota,ND
+34,Ohio,OH
+35,Oklahoma,OK
+36,Oregon,OR
+37,Pennsylvania,PA
+38,Rhode Island,RI
+39,South Carolina,SC
+40,South Dakota,SD
+41,Tennessee,TN
+42,Texas,TX
+43,Utah,UT
+44,Vermont,VT
+45,Virginia,VA
+46,Washington,WA
+47,West Virginia,WV
+48,Wisconsin,WI
+49,Wyoming,WY

--- a/Docker/SqlServer/initialize_and_start_sqlserver.sh
+++ b/Docker/SqlServer/initialize_and_start_sqlserver.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 { 
-    # Wait 30 seconds for SQL server to start up.
-    # Ideally, SQL server would have a hook to run scripts once the database is ready.
-    sleep 30s
+    # Wait for SQL Server to start up
+    # Check if the server is ready
+    not_ready=1
+    while [ $not_ready != 0 ]
+    do
+        # Wait for the return code of the following statement to be zero
+        /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P magenicMAQS2 -d master -Q "SELECT TOP 1 message_id FROM sys.messages"
+        not_ready=$?
+
+        if [ $not_ready != 0 ]
+        then
+            echo "Could not contact sql server, will try again in 5 seconds."
+            sleep 5s
+        fi
+    done
+
     echo "Started initializing database"
     # Set up the schema and stored procedures
     /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P magenicMAQS2 -d master -i `dirname $0`/schema.sql

--- a/Docker/SqlServer/initialize_and_start_sqlserver.sh
+++ b/Docker/SqlServer/initialize_and_start_sqlserver.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+{ 
+    # Wait 30 seconds for SQL server to start up.
+    # Ideally, SQL server would have a hook to run scripts once the database is ready.
+    sleep 30s
+    echo "Started initializing database"
+    # Set up the schema and stored procedures
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P magenicMAQS2 -d master -i `dirname $0`/schema.sql
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P magenicMAQS2 -d master -i `dirname $0`/stored_procedures.sql
+    # Use BCP to import test data
+    /opt/mssql-tools/bin/bcp MagenicAutomation.dbo.States in "`dirname $0`/SeedData/MagenicAutomation/States.csv" \
+        -c -t',' -S localhost -U sa -P magenicMAQS2
+    echo "Finished initializing database"
+}&
+
+# Start SQL server
+exec /opt/mssql/bin/sqlservr

--- a/Docker/SqlServer/schema.sql
+++ b/Docker/SqlServer/schema.sql
@@ -1,0 +1,10 @@
+CREATE DATABASE MagenicAutomation;
+GO
+USE MagenicAutomation;
+GO
+CREATE TABLE [dbo].[States](
+	[StateID] [int] PRIMARY KEY IDENTITY(1,1) NOT NULL,
+	[StateName] [nvarchar](max) NOT NULL,
+	[StateAbbreviation] [nvarchar](2) NULL
+);
+GO

--- a/Docker/SqlServer/stored_procedures.sql
+++ b/Docker/SqlServer/stored_procedures.sql
@@ -1,0 +1,17 @@
+USE MagenicAutomation;
+GO
+CREATE PROCEDURE [dbo].[getStateAbbrevMatch]
+       @StateAbbreviation VARCHAR(2)
+  AS BEGIN
+    SELECT StateAbbreviation FROM States
+    WHERE StateAbbreviation = @StateAbbreviation
+  END 
+GO
+CREATE PROCEDURE [dbo].[setStateAbbrevToSelf]
+       @StateAbbreviation VARCHAR(2)
+  AS BEGIN
+    UPDATE States
+    SET StateAbbreviation = @StateAbbreviation 
+    WHERE StateAbbreviation = @StateAbbreviation
+  END 
+GO

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.1'
+
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:latest
+    ports:
+      - 1433:1433
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=magenicMAQS2
+      - MSSQL_PID=Developer
+    expose:
+      - 1433
+    volumes:
+      # Mount the current directory onto /mnt/host on the image.
+      - ./SqlServer/:/mnt/host/
+    # Run a custom bash script that bootstraps the database after it is started.
+    command: ['/bin/bash', '/mnt/host/initialize_and_start_sqlserver.sh']

--- a/Framework/DatabaseUnitTests/App.config
+++ b/Framework/DatabaseUnitTests/App.config
@@ -40,6 +40,6 @@
     <add key="DataBaseConnectionString" value=""DATA SOURCE=server;PERSIST SECURITY INFO=True;USER ID=User;password=pw;Pooling=False;" />
     -->
     <add key="DataBaseProviderType" value="SQLSERVER" />
-    <add key="DataBaseConnectionString" value="Data Source=qasqlserver.database.windows.net;Initial Catalog=MagenicAutomation;Persist Security Info=True;User ID=MagenicQA;Password=1magenicMARQ;Connection Timeout=30" />
+    <add key="DataBaseConnectionString" value="Data Source=localhost;Initial Catalog=MagenicAutomation;Persist Security Info=True;User ID=sa;Password=magenicMAQS2;Connection Timeout=30" />
   </DatabaseMaqs>
 </configuration>


### PR DESCRIPTION
In the interests of making the integration tests more like unit tests, and also to not depend on external resources in testing, this pull request seeks to provide resources for initializing and seeding SQL server for the unit tests.

To get the tests to not fail at the build stage, some changes will have to be done on the CI/CD side to ensure the Docker compose file is ran before the tests are executed. I haven't touched the actual build/testing pipeline.

The database is seeded by building the stored procedures using SQL and using BCP to import a CSV for the one table the current tests depend on (if anything was missed, please let me know).