### PR TITLE
Utilities Linux Parity

### DIFF
--- a/Framework/Utilities/Performance/PerfTimerCollection.cs
+++ b/Framework/Utilities/Performance/PerfTimerCollection.cs
@@ -154,13 +154,13 @@ namespace Magenic.Maqs.Utilities.Performance
                             this.FileName = "PerformanceTimerResults" + "-" + this.TestName + "-" + DateTime.UtcNow.ToString("O").Replace(':', '-') + ".xml";
                         }
 
-                        log.LogMessage(MessageType.INFORMATION, "filename: " + LoggingConfig.GetLogDirectory() + "\\" + this.FileName);
+                        log.LogMessage(MessageType.INFORMATION, "filename: " + LoggingConfig.GetLogDirectory() + Path.DirectorySeparatorChar + this.FileName);
 
                         XmlWriterSettings settings = new XmlWriterSettings();
                         settings.WriteEndDocumentOnClose = true;
                         settings.Indent = true;
                         
-                        XmlWriter writer = XmlWriter.Create(string.Format("{0}\\{1}", LoggingConfig.GetLogDirectory(), this.FileName), settings);
+                        XmlWriter writer = XmlWriter.Create(string.Format("{0}{2}{1}", LoggingConfig.GetLogDirectory(), this.FileName, Path.DirectorySeparatorChar), settings);
 
                         XmlSerializer x = new XmlSerializer(this.GetType());
                         x.Serialize(writer, this);

--- a/Framework/UtilitiesUnitTests/PerformanceUnitTests.cs
+++ b/Framework/UtilitiesUnitTests/PerformanceUnitTests.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 
 namespace UtilitiesUnitTesting
 {
@@ -219,12 +220,13 @@ namespace UtilitiesUnitTesting
         [TestCategory(TestCategories.Utilities)]
         public void PerfTimerWriteException()
         {
-            // Invalid testName
-            PerfTimerCollection p = new PerfTimerCollection("<>");
+            // Create an invalid testName using characters not allowed on host OS
+            PerfTimerCollection p = new PerfTimerCollection("<>" + Path.GetInvalidFileNameChars().Aggregate("", (curr, next) => curr + next));
             p.StartTimer("testTimer");
             p.EndTimer("testTimer");
             FileLogger log = new FileLogger("PerfTimerWriteException", "PerfTimerWriteException", MessageType.GENERIC, true);
             p.Write(log);
+            // Tests that an exception is thrown and logged.
             Assert.IsTrue(File.ReadAllText(log.FilePath).Contains("Could not save response time file.  Error was:"));
         }
 

--- a/Framework/UtilitiesUnitTests/StringProcessorUnitTests.cs
+++ b/Framework/UtilitiesUnitTests/StringProcessorUnitTests.cs
@@ -28,7 +28,7 @@ namespace UtilitiesUnitTesting
         public void StringFormatterCheckForJson()
         {
             string message = StringProcessor.SafeFormatter("{This is a test for JSON}");
-            Assert.AreEqual("{This is a test for JSON}\r\n", message);
+            Assert.AreEqual("{This is a test for JSON}" + Environment.NewLine, message);
         }
 
         /// <summary>

--- a/Framework/UtilitiesUnitTests/appsettings.json
+++ b/Framework/UtilitiesUnitTests/appsettings.json
@@ -7,7 +7,7 @@
     "LogType": "TXT",
     "Grog": "WillFailWithoutRunSettingOverride",
     "SectionOverrideCore": "WillFailWithoutRunSettingOverride",
-    "CustomLogPath": "C:\\FrameworksCustomTempDeleteME\\",
+    "CustomLogPath": "tmp/logs/",
     "SimpleOverride": "simple",
     "Override": "base",
     "Override2": "base2"


### PR DESCRIPTION
The goal of this pull request is to modify both `Magenic.Maqs.Utilities` and it's unit tests so that behavior is consistent across Windows and Linux.

This pull request addresses two small issues in the Utilities unit tests:
* The `StringFormatterCheckForJson` test currently uses a hard coded carriage return then line feed for a new line, but on Linux the newlines are only encoded using a line feed. [Environment.NewLine](https://docs.microsoft.com/en-us/dotnet/api/system.environment.newline) resolves to what ever the appropriate new line sequence is of the current environment, which fixes the test to work in both systems.
    * I am assuming that using a line feed as a newline delimiter for MAQS on Linux is the expected behavior.
* The `PerfTimerWriteException` test assumes that `<>` is an invalid filename, but on some popular Linux file systems `<>` is a perfectly valid filename. The goal of this test is to ensure that an exception is thrown with an invalid filename, so I fixed this by appending all the chars from [Path.GetInvalidFileNameChars()](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getinvalidfilenamechars) to the filename, which should cause the exception to be thrown.

This pull request also changes the `CustomLogPath` configuration value to work as expected with both Unix and Windows style paths, by changing the way paths are built by the `PerfTimerCollection`. Instead of using a hardcoded `\`, the [Path.DirectorySeperatorChar](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.directoryseparatorchar) is used. This is because on some non-Windows file systems, `\` is a perfectly valid character to have in a filename, which will lead to `\` being interpreted as a directory separator on Windows and as a part of the filename on non-Windows. 

While this guarantees consistent behavior across both Windows and Linux systems, there are some concerns of backwards compatibility if someone is already using MAQS on a non-Windows system. If they have already architected a solution that depends on the old behavior, this change could potentially break those implementations.

Thanks a lot, please let me know your thoughts.