### PR TITLE
Updating Axe to 2.0.0

### DIFF
--- a/Framework/BaseSeleniumTest/BaseSeleniumTest.csproj
+++ b/Framework/BaseSeleniumTest/BaseSeleniumTest.csproj
@@ -50,7 +50,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.Axe" Version="1.5.2" />
+    <PackageReference Include="Selenium.Axe" Version="2.0.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />

--- a/Framework/BaseSeleniumTest/SeleniumUtilities.cs
+++ b/Framework/BaseSeleniumTest/SeleniumUtilities.cs
@@ -424,7 +424,7 @@ namespace Magenic.Maqs.BaseSeleniumTest
                 {
                     message.AppendLine($@"{"\t"}{"\t"}HTML element: {item.Html}");
 
-                    foreach (string target in item.Target)
+                    foreach (var target in item.Target)
                     {
                         message.AppendLine($@"{"\t"}{"\t"}Selector: {target}");
                     }
@@ -464,10 +464,10 @@ namespace Magenic.Maqs.BaseSeleniumTest
         /// <param name="element">The web element</param>
         /// <returns>The web driver</returns>
         public static IWebDriver WebElementToWebDriver(IWebElement element)
-        {            
+        {
             // Extract the web driver from the element
             IWebDriver driver;
-            
+
             // Get the parent driver - this is a protected property so we need to user reflection to access it
             var eventFiringPropertyInfo = element.GetType().GetProperty("ParentDriver", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.GetProperty);
 


### PR DESCRIPTION
@TroyWalshProf  All unit tests pass with the change.  Looks like it changed from a string to a AxeResultTarget which has an overridden ToString

https://github.com/TroyWalshProf/SeleniumAxeDotnet/pull/91