### PR TITLE
Restructure web service driver and event firing driver.

### DIFF
--- a/Framework/BaseWebServiceTest/EventFiringWebServiceDriver.cs
+++ b/Framework/BaseWebServiceTest/EventFiringWebServiceDriver.cs
@@ -265,27 +265,33 @@ namespace Magenic.Maqs.BaseWebServiceTest
         private void BuildContentMessage(StringBuilder message, string mediaType, HttpContent content)
         {
             message.AppendLine("Content:");
-            message.AppendLine($"  Content Media Type: {mediaType}");
-            message.AppendLine("  Content Text:");
-            if (mediaType != null)
-            { 
+            
+            if (string.IsNullOrEmpty(mediaType))
+            {
+                message.AppendLine("  **Content media type is null or empty**");
+            }
+            else
+            {
+                message.AppendLine($"  Content Media Type: {mediaType}");
+                message.AppendLine("  Content Text:");
+
                 mediaType = mediaType.ToUpper();
-                
+
                 if (mediaType.Contains("TEXT") || mediaType.Contains("XML") || mediaType.Contains("JSON") || mediaType.Contains("HTML"))
                 {
                     if (content != null)
                     {
                         message.AppendLine(content.ReadAsStringAsync().Result);
                     }
+                    else
+                    {
+                        message.AppendLine("  **Content is null**");
+                    }
                 }
                 else
                 {
                     message.AppendLine("  **Writting this kind of content to the log is not supported**");
                 }
-            }
-            else
-            {
-                message.AppendLine("  **Content is NULL**");
             }
         }
     }

--- a/Framework/BaseWebServiceTest/EventFiringWebServiceDriver.cs
+++ b/Framework/BaseWebServiceTest/EventFiringWebServiceDriver.cs
@@ -6,9 +6,9 @@
 //--------------------------------------------------
 using Magenic.Maqs.Utilities.Data;
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Magenic.Maqs.BaseWebServiceTest
 {
@@ -85,46 +85,21 @@ namespace Magenic.Maqs.BaseWebServiceTest
         }
 
         /// <summary>
-        /// Do a web service post for the given uri, content and media type
+        /// Execute a web service call 
         /// </summary>
-        /// <param name="requestUri">The request uri</param>
-        /// <param name="responseMediaType">The response media type</param>
-        /// <param name="content">The post body</param>
+        /// <param name="methodVerb">The HTTP verb</param>
+        /// <param name="requestUri">The requested URI</param>
+        /// <param name="expectedMediaType">The expected media type</param>
         /// <param name="expectSuccess">Assert a success code was returned</param>
-        /// <returns>A http response message</returns>
-        protected override async Task<HttpResponseMessage> PostContent(string requestUri, string responseMediaType, HttpContent content, bool expectSuccess = true)
-        {
-            try
-            {
-                RaiseEvent(content, "Post", requestUri, responseMediaType);
-                HttpResponseMessage response = base.PostContent(requestUri, responseMediaType, content, expectSuccess).GetAwaiter().GetResult();
-                RaiseEvent("Post", response);
-                return await Task.FromResult(response);
-            }
-            catch (Exception e)
-            {
-                RaiseErrorMessage(e);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Make a HTTP call using the custom verb to the URI with the given verb, media response type and content
-        /// </summary>
-        /// <param name="requestUri">The request URI</param>
-        /// <param name="customVerb">Custom HTTP Verb</param>
-        /// <param name="responseMediaType">Response media type</param>
-        /// <param name="content">Content of the message</param>
-        /// <param name="expectSuccess">Assert a success status code was returned</param>
         /// <returns>The HTTP response message</returns>
-        protected override async Task<HttpResponseMessage> CustomContent(string requestUri, string customVerb, string responseMediaType, HttpContent content, bool expectSuccess = true)
+        protected override HttpResponseMessage CallWithResponse(string methodVerb, string requestUri, string expectedMediaType, bool expectSuccess = true)
         {
             try
             {
-                RaiseEvent(content, customVerb, requestUri, responseMediaType);
-                HttpResponseMessage response = base.CustomContent(requestUri, customVerb, responseMediaType, content, expectSuccess).GetAwaiter().GetResult();
-                RaiseEvent(customVerb, response);
-                return await Task.FromResult(response);
+                RaiseEvent(methodVerb, requestUri, expectedMediaType);
+                HttpResponseMessage response = base.CallWithResponse(methodVerb, requestUri, expectedMediaType, expectSuccess);
+                RaiseEvent(methodVerb, response);
+                return response;
             }
             catch (Exception e)
             {
@@ -134,21 +109,47 @@ namespace Magenic.Maqs.BaseWebServiceTest
         }
 
         /// <summary>
-        /// Do a web service put for the given uri, content and media type
+        /// Execute a web service call 
         /// </summary>
-        /// <param name="requestUri">The request uri</param>
+        /// <param name="methodVerb">The HTTP verb</param>
+        /// <param name="requestUri">The requested URI</param>
+        /// <param name="expectedMediaType">The expected media type</param>
+        /// <param name="expectedStatus">Assert a specific status code was returned</param>
+        /// <returns>The HTTP response message</returns>
+        protected override HttpResponseMessage CallWithResponse(string methodVerb, string requestUri, string expectedMediaType, HttpStatusCode expectedStatus)
+        {
+            try
+            {
+                RaiseEvent(methodVerb, requestUri, expectedMediaType);
+                HttpResponseMessage response = base.CallWithResponse(methodVerb, requestUri, expectedMediaType, expectedStatus);
+                RaiseEvent(methodVerb, response);
+                return response;
+            }
+            catch (Exception e)
+            {
+                RaiseErrorMessage(e);
+                throw;
+            }
+
+        }
+
+        /// <summary>
+        /// Execute a web service call 
+        /// </summary>
+        /// <param name="methodVerb">The HTTP verb</param>
+        /// <param name="requestUri">The requested URI</param>
         /// <param name="responseMediaType">The response media type</param>
-        /// <param name="content">The put body</param>
+        /// <param name="content">The content</param>
         /// <param name="expectSuccess">Assert a success code was returned</param>
-        /// <returns>A http response message</returns>
-        protected override async Task<HttpResponseMessage> PutContent(string requestUri, string responseMediaType, HttpContent content, bool expectSuccess = true)
+        /// <returns>The HTTP response message</returns>
+        protected override HttpResponseMessage CallContentWithResponse(string methodVerb, string requestUri, string responseMediaType, HttpContent content, bool expectSuccess = true)
         {
             try
             {
-                RaiseEvent(content, "Put", requestUri, responseMediaType);
-                HttpResponseMessage response = base.PutContent(requestUri, responseMediaType, content, expectSuccess).GetAwaiter().GetResult();
-                RaiseEvent("Put", response);
-                return await Task.FromResult(response);
+                RaiseEvent(content, methodVerb, requestUri, responseMediaType);
+                HttpResponseMessage response = base.CallContentWithResponse(methodVerb, requestUri, responseMediaType, content, expectSuccess);
+                RaiseEvent(methodVerb, response);
+                return response;
             }
             catch (Exception e)
             {
@@ -158,43 +159,22 @@ namespace Magenic.Maqs.BaseWebServiceTest
         }
 
         /// <summary>
-        /// Do a web service delete for the given uri
+        /// Execute a web service call 
         /// </summary>
-        /// <param name="requestUri">The request uri</param>
-        /// <param name="returnMediaType">The expected response media type</param>
-        /// <param name="expectSuccess">Assert a success code was returned</param>
-        /// <returns>A http response message</returns>
-        protected override async Task<HttpResponseMessage> DeleteContent(string requestUri, string returnMediaType, bool expectSuccess = true)
+        /// <param name="methodVerb">The HTTP verb</param>
+        /// <param name="requestUri">The requested URI</param>
+        /// <param name="responseMediaType">The response media type</param>
+        /// <param name="content">The content</param>
+        /// <param name="expectedStatus">Assert a specific status code was returned</param>
+        /// <returns>The HTTP response message</returns>
+        protected override HttpResponseMessage CallContentWithResponse(string methodVerb, string requestUri, string responseMediaType, HttpContent content, HttpStatusCode expectedStatus)
         {
             try
             {
-                RaiseEvent("Delete", requestUri, returnMediaType);
-                HttpResponseMessage response = base.DeleteContent(requestUri, returnMediaType, expectSuccess).GetAwaiter().GetResult();
-                RaiseEvent("Delete", response);
-                return await Task.FromResult(response);
-            }
-            catch (Exception e)
-            {
-                RaiseErrorMessage(e);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Do a web service get for the given uri and media type
-        /// </summary>
-        /// <param name="requestUri">The request uri</param>
-        /// <param name="mediaType">What type of media are we expecting</param>
-        /// <param name="expectSuccess">Assert a success code was returned</param>
-        /// <returns>A http response message</returns>
-        protected override async Task<HttpResponseMessage> GetContent(string requestUri, string mediaType, bool expectSuccess = true)
-        {
-            try
-            {
-                RaiseEvent("Get", requestUri, mediaType);
-                HttpResponseMessage response = base.GetContent(requestUri, mediaType, expectSuccess).GetAwaiter().GetResult();
-                RaiseEvent("Get", response);
-                return await Task.FromResult(response);
+                RaiseEvent(content, methodVerb, requestUri, responseMediaType);
+                HttpResponseMessage response = base.CallContentWithResponse(methodVerb, requestUri, responseMediaType, content, expectedStatus);
+                RaiseEvent(methodVerb, response);
+                return response;
             }
             catch (Exception e)
             {
@@ -228,17 +208,7 @@ namespace Magenic.Maqs.BaseWebServiceTest
                 StringBuilder message = new StringBuilder();
                 message.AppendLine(StringProcessor.SafeFormatter("Send {0} request with content to base: '{1}' endpoint: '{2}' with the media type: '{3}'", actionType, HttpClient.BaseAddress, requestUri, mediaType));
 
-                mediaType = mediaType.ToUpper();
-
-                if (mediaType.Contains("TEXT") || mediaType.Contains("XML") || mediaType.Contains("JSON"))
-                {
-                    message.AppendLine("Content:");
-
-                    if (content != null)
-                    {
-                        message.AppendLine(content.ReadAsStringAsync().Result);
-                    }
-                }
+                BuildContentMessage(message, mediaType, content);
 
                 OnActionEvent(message.ToString());
             }
@@ -265,17 +235,8 @@ namespace Magenic.Maqs.BaseWebServiceTest
                 // Only pull content if we are returned content
                 if (response.Content.Headers.ContentType != null)
                 {
-                    string mediaType = response.Content.Headers.ContentType.MediaType.ToUpper();
-
-                    // Only add the text if we know it is human readable
-                    if (mediaType.Contains("TEXT") || mediaType.Contains("XML") || mediaType.Contains("JSON"))
-                    {
-                        message.AppendLine("Content:");
-                        if (response.Content != null)
-                        {
-                            message.AppendLine(response.Content.ReadAsStringAsync().Result);
-                        }
-                    }
+                    string mediaType = response.Content.Headers.ContentType.MediaType;
+                    BuildContentMessage(message, mediaType, response.Content);
                 }
 
                 OnEvent(message.ToString());
@@ -293,6 +254,39 @@ namespace Magenic.Maqs.BaseWebServiceTest
         private void RaiseErrorMessage(Exception e)
         {
             OnErrorEvent(StringProcessor.SafeFormatter("Failed because: {0} {1} {2}", e.Message, Environment.NewLine, e.ToString()));
+        }
+
+        /// <summary>
+        /// Build the content massage
+        /// </summary>
+        /// <param name="message">String builder for building the message</param>
+        /// <param name="mediaType">Content media type</param>
+        /// <param name="content">The content we are building a message for</param>
+        private void BuildContentMessage(StringBuilder message, string mediaType, HttpContent content)
+        {
+            message.AppendLine("Content:");
+            message.AppendLine($"  Content Media Type: {mediaType}");
+            message.AppendLine("  Content Text:");
+            if (mediaType != null)
+            { 
+                mediaType = mediaType.ToUpper();
+                
+                if (mediaType.Contains("TEXT") || mediaType.Contains("XML") || mediaType.Contains("JSON") || mediaType.Contains("HTML"))
+                {
+                    if (content != null)
+                    {
+                        message.AppendLine(content.ReadAsStringAsync().Result);
+                    }
+                }
+                else
+                {
+                    message.AppendLine("  **Writting this kind of content to the log is not supported**");
+                }
+            }
+            else
+            {
+                message.AppendLine("  **Content is NULL**");
+            }
         }
     }
 }

--- a/Framework/BaseWebServiceTest/WebServiceVerb.cs
+++ b/Framework/BaseWebServiceTest/WebServiceVerb.cs
@@ -1,0 +1,40 @@
+﻿//--------------------------------------------------
+// <copyright file="WebServiceVerb.cs" company="Magenic">
+//  Copyright 2021 Magenic, All rights Reserved
+// </copyright>
+// <summary>Web service verb constants</summary>
+//--------------------------------------------------
+
+namespace Magenic.Maqs.BaseWebServiceTest
+{
+    /// <summary>
+    ///  Web service verb constants
+    /// </summary>
+    public static class WebServiceVerb
+    {
+        /// <summary>
+        /// String for web service get verb
+        /// </summary>
+        public const string Get = "GET";
+
+        /// <summary>
+        /// String for web service put verb
+        /// </summary>
+        public const string Put = "PUT";
+
+        /// <summary>
+        /// String for web service post verb
+        /// </summary>
+        public const string Post = "POST";
+
+        /// <summary>
+        /// String for web service patch verb
+        /// </summary>
+        public const string Patch = "PATCH";
+
+        /// <summary>
+        /// String for web service delete verb
+        /// </summary>
+        public const string Delete = "DELETE";
+    }
+}

--- a/Framework/Utilities/Helper/TestCategories.cs
+++ b/Framework/Utilities/Helper/TestCategories.cs
@@ -2,13 +2,13 @@
 // <copyright file="TestCategories.cs" company="Magenic">
 //  Copyright 2021 Magenic, All rights Reserved
 // </copyright>
-// <summary>Web service MediaType class page</summary>
+// <summary>Test category constants</summary>
 //--------------------------------------------------
 
 namespace Magenic.Maqs.Utilities.Helper
 {
     /// <summary>
-    ///  Test category type of web service
+    ///  Test category constants
     /// </summary>
     public static class TestCategories
     {

--- a/Framework/WebServiceUnitTests/EventFiringWebServiceDriverTests.cs
+++ b/Framework/WebServiceUnitTests/EventFiringWebServiceDriverTests.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 using WebServiceTesterUnitTesting.Model;
 
@@ -25,7 +26,7 @@ namespace WebServiceTesterUnitTesting
         /// <summary>
         /// Default baseAddress for default constructor
         /// </summary>
-        private static string baseAddress = WebServiceConfig.GetWebServiceUri();
+        private static readonly string baseAddress = WebServiceConfig.GetWebServiceUri();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventFiringWebServiceDriverTests"/> class
@@ -39,10 +40,10 @@ namespace WebServiceTesterUnitTesting
         /// </summary>
         [TestMethod]
         [TestCategory(TestCategories.WebService)]
-        [ExpectedException(typeof(AggregateException))]
+        [ExpectedException(typeof(HttpRequestException))]
         public void PostContentThrowException()
         {
-            PostContent("BAD", null, null).Wait();
+            CallContentWithResponse(WebServiceVerb.Post, "BAD", null, null);
         }
 
         /// <summary>
@@ -50,10 +51,10 @@ namespace WebServiceTesterUnitTesting
         /// </summary>
         [TestMethod]
         [TestCategory(TestCategories.WebService)]
-        [ExpectedException(typeof(AggregateException))]
+        [ExpectedException(typeof(HttpRequestException))]
         public void PutContentThrowException()
         {
-            PutContent("BAD", null, null).Wait();
+            CallContentWithResponse(WebServiceVerb.Put, "BAD", null, null);
         }
 
         /// <summary>
@@ -61,10 +62,10 @@ namespace WebServiceTesterUnitTesting
         /// </summary>
         [TestMethod]
         [TestCategory(TestCategories.WebService)]
-        [ExpectedException(typeof(AggregateException))]
+        [ExpectedException(typeof(HttpRequestException))]
         public void DeleteContentThrowException()
         {
-            DeleteContent("BAD", null).Wait();
+            CallWithResponse(WebServiceVerb.Delete, "BAD", null);
         }
 
         /// <summary>
@@ -72,10 +73,10 @@ namespace WebServiceTesterUnitTesting
         /// </summary>
         [TestMethod]
         [TestCategory(TestCategories.WebService)]
-        [ExpectedException(typeof(AggregateException))]
+        [ExpectedException(typeof(HttpRequestException))]
         public void GetContentThrowException()
         {
-            GetContent("BAD", null).Wait();
+            CallWithResponse(WebServiceVerb.Get, "BAD", null);
         }
 
         /// <summary>
@@ -83,10 +84,10 @@ namespace WebServiceTesterUnitTesting
         /// </summary>
         [TestMethod]
         [TestCategory(TestCategories.WebService)]
-        [ExpectedException(typeof(AggregateException))]
+        [ExpectedException(typeof(HttpRequestException))]
         public void CustomContentThrowException()
         {
-            CustomContent("BAD", null, null, null).Wait();
+            CallContentWithResponse("BAD", "BAD", null, null);
         }
 
         /// <summary>
@@ -105,7 +106,7 @@ namespace WebServiceTesterUnitTesting
             };
 
             var content = WebServiceUtils.MakeStreamContent<Product>(p, Encoding.UTF8, "application/xml");
-            var result = PostContent("/api/XML_JSON/Post", "application/xml", content, true).Result;
+            var result = CallContentWithResponse(WebServiceVerb.Post, "/api/XML_JSON/Post", "application/xml", content, true);
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
         }
 
@@ -117,7 +118,7 @@ namespace WebServiceTesterUnitTesting
         public void VerifyCustomContent()
         {
             var content = WebServiceUtils.MakeStringContent("ZED?", Encoding.UTF8, "application/json");
-            var result = CustomContent("/api/ZED", "ZED", "application/json", content, false).Result;
+            var result = CallContentWithResponse("ZED", "/api/ZED", "application/json", content, false);
             Assert.AreEqual(HttpStatusCode.UseProxy, result.StatusCode);
         }
 
@@ -136,7 +137,7 @@ namespace WebServiceTesterUnitTesting
                 Price = 3.25f
             };
             var content = WebServiceUtils.MakeStringContent<Product>(p, Encoding.UTF8, "application/xml");
-            var result = PutContent("/api/XML_JSON/Put/1", "application/xml", content).Result;
+            var result = CallContentWithResponse(WebServiceVerb.Put, "/api/XML_JSON/Put/1", "application/xml", content);
 
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
         }
@@ -148,7 +149,7 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void VerifyDeleteContent()
         {
-            var result = DeleteContent("/api/String/Delete/1", "text/plain", true).Result;
+            var result = CallWithResponse(WebServiceVerb.Delete, "/api/String/Delete/1", "text/plain", true);
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
         }
 
@@ -159,7 +160,7 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void VerifyGetContent()
         {
-            var result = GetContent("/api/String/1", "text/plain").Result;
+            var result = CallWithResponse(WebServiceVerb.Get, "/api/String/1", "text/plain");
             Assert.IsFalse(string.IsNullOrEmpty(result.Content.ReadAsStringAsync().Result), "Expected a result to be returned");
         }
 

--- a/Framework/WebServiceUnitTests/EventFiringWebServiceDriverTests.cs
+++ b/Framework/WebServiceUnitTests/EventFiringWebServiceDriverTests.cs
@@ -123,6 +123,30 @@ namespace WebServiceTesterUnitTesting
         }
 
         /// <summary>
+        /// Verify custom content works with a specific response code
+        /// </summary>
+        [TestMethod]
+        [TestCategory(TestCategories.WebService)]
+        public void VerifyCustomContentWithResponseCode()
+        {
+            var content = WebServiceUtils.MakeStringContent("ZED?", Encoding.UTF8, "application/json");
+            var result = CallContentWithResponse("ZED", "/api/ZED", "application/json", content, HttpStatusCode.UseProxy);
+            Assert.AreEqual(HttpStatusCode.UseProxy, result.StatusCode);
+        }
+
+        /// <summary>
+        /// Verify custom content works with non standard content type
+        /// </summary>
+        [TestMethod]
+        [TestCategory(TestCategories.WebService)]
+        public void VerifyCustomNonStandardContent()
+        {
+            var content = WebServiceUtils.MakeStringContent("ZED?", Encoding.UTF8, "application/json");
+            var result = CallContentWithResponse("ZED", "/api/ZED", "application/nosj", content, false);
+            Assert.AreEqual(HttpStatusCode.UseProxy, result.StatusCode);
+        }
+
+        /// <summary>
         /// Verify put content works
         /// </summary>
         [TestMethod]
@@ -161,6 +185,17 @@ namespace WebServiceTesterUnitTesting
         public void VerifyGetContent()
         {
             var result = CallWithResponse(WebServiceVerb.Get, "/api/String/1", "text/plain");
+            Assert.IsFalse(string.IsNullOrEmpty(result.Content.ReadAsStringAsync().Result), "Expected a result to be returned");
+        }
+
+        /// <summary>
+        /// Verify get content works with a specific response code
+        /// </summary>
+        [TestMethod]
+        [TestCategory(TestCategories.WebService)]
+        public void VerifyGetContentWithResponseCode()
+        {
+            var result = CallWithResponse(WebServiceVerb.Get, "/api/String/1", "text/plain", HttpStatusCode.OK);
             Assert.IsFalse(string.IsNullOrEmpty(result.Content.ReadAsStringAsync().Result), "Expected a result to be returned");
         }
 

--- a/Framework/WebServiceUnitTests/WebServiceGets.cs
+++ b/Framework/WebServiceUnitTests/WebServiceGets.cs
@@ -26,7 +26,7 @@ namespace WebServiceTesterUnitTesting
         /// <summary>
         /// String to hold the URL
         /// </summary>
-        private static string url = WebServiceConfig.GetWebServiceUri();
+        private static readonly string url = WebServiceConfig.GetWebServiceUri();
 
         /// <summary>
         /// Make sure the web service have been woken up
@@ -35,6 +35,11 @@ namespace WebServiceTesterUnitTesting
         [AssemblyInitialize]
         public static void PrimeSite(TestContext context)
         {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             try
             {
                 WebServiceDriver client = new WebServiceDriver(new Uri("https://magenicautomation.azurewebsites.net"));

--- a/Framework/WebServiceUnitTests/WebServicePatches.cs
+++ b/Framework/WebServiceUnitTests/WebServicePatches.cs
@@ -25,7 +25,7 @@ namespace WebServiceTesterUnitTesting
         /// <summary>
         /// String to hold the URL
         /// </summary>
-        private static string url = WebServiceConfig.GetWebServiceUri();
+        private static readonly string url = WebServiceConfig.GetWebServiceUri();
         
         /// <summary>
         /// Verify the string status code
@@ -35,11 +35,14 @@ namespace WebServiceTesterUnitTesting
         public void PatchJSONWithoutBaseTest()
         {
             WebServiceDriver client = new WebServiceDriver(new Uri(url));
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
+
             var content = WebServiceUtils.MakeStringContent<ProductJson>(p, Encoding.UTF8, "application/json");
             var result = client.PatchWithResponse("/api/XML_JSON/Patch/1", "application/json", content, true);
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
@@ -53,11 +56,14 @@ namespace WebServiceTesterUnitTesting
         public void PatchJSONWithTypeWithoutBaseTest()
         {
             WebServiceDriver client = new WebServiceDriver(new Uri(url));
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
+
             var content = WebServiceUtils.MakeStringContent<ProductJson>(p, Encoding.UTF8, "application/json");
             var result = client.Patch<ProductJson>("/api/XML_JSON/Patch/1", "application/json", content, true);
             Assert.AreEqual(p.Category, result.Category);

--- a/Framework/WebServiceUnitTests/WebServiceStatusCodes.cs
+++ b/Framework/WebServiceUnitTests/WebServiceStatusCodes.cs
@@ -62,11 +62,14 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PostTypeParamWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
+
             var req = WebServiceUtils.MakeStringContent<ProductJson>(p, Encoding.UTF8, "application/json");
             var res = this.WebServiceDriver.Post<ProductJson>("/api/XML_JSON/Post", "application/json", req, HttpStatusCode.OK);
             Assert.IsNull(res);
@@ -79,11 +82,14 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PostWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
+
             var req = WebServiceUtils.MakeStringContent<ProductJson>(p, Encoding.UTF8, "application/json");
             var res = this.WebServiceDriver.Post("/api/XML_JSON/Post", "application/json", req, HttpStatusCode.OK);
             Assert.IsNotNull(res);
@@ -96,11 +102,13 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PostMoreParamsWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
 
             var res = this.WebServiceDriver.Post("/api/XML_JSON/Post", "application/json", JsonConvert.SerializeObject(p), Encoding.UTF8, "application/json", HttpStatusCode.OK, true);
             Assert.IsNotNull(res);
@@ -113,11 +121,13 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PostMoreParamsWithResponseWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
 
             var res = this.WebServiceDriver.PostWithResponse("/api/XML_JSON/Post", "application/json", JsonConvert.SerializeObject(p), Encoding.UTF8, "application/json", HttpStatusCode.OK, true);
             Assert.IsNotNull(res);
@@ -130,11 +140,14 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PostWithResponseWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
+
             var req = WebServiceUtils.MakeStringContent<ProductJson>(p, Encoding.UTF8, "application/json");
             var res = this.WebServiceDriver.PostWithResponse("/api/XML_JSON/Post", "application/json", req, HttpStatusCode.OK);
             Assert.IsNotNull(res);
@@ -242,11 +255,14 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PatchTypeParamWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
+
             var req = WebServiceUtils.MakeStringContent<ProductJson>(p, Encoding.UTF8, "application/json");
             var res = this.WebServiceDriver.Patch<ProductJson>("/api/XML_JSON/Patch/1", "application/json", req, HttpStatusCode.OK);
             Assert.IsNotNull(res);
@@ -259,11 +275,14 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PatchWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
+
             var req = WebServiceUtils.MakeStringContent<ProductJson>(p, Encoding.UTF8, "application/json");
             var res = this.WebServiceDriver.Patch("/api/XML_JSON/Patch/1", "application/json", req, HttpStatusCode.OK);
             Assert.IsNotNull(res);
@@ -276,11 +295,13 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PatchMoreParamsWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
 
             var res = this.WebServiceDriver.Patch("/api/XML_JSON/Patch/1", "application/json", JsonConvert.SerializeObject(p), Encoding.UTF8, "application/json", HttpStatusCode.OK, true);
             Assert.IsNotNull(res);
@@ -293,11 +314,13 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PatchMoreParamsWithResponseWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
 
             var res = this.WebServiceDriver.PatchWithResponse("/api/XML_JSON/Patch/1", "application/json", JsonConvert.SerializeObject(p), Encoding.UTF8, "application/json", HttpStatusCode.OK, true);
             Assert.IsNotNull(res);
@@ -310,11 +333,14 @@ namespace WebServiceTesterUnitTesting
         [TestCategory(TestCategories.WebService)]
         public void PatchWithResponseWithExpectedStatus()
         {
-            ProductJson p = new ProductJson();
-            p.Category = "ff";
-            p.Id = 4;
-            p.Name = "ff";
-            p.Price = 3.25f;
+            ProductJson p = new ProductJson
+            {
+                Category = "ff",
+                Id = 4,
+                Name = "ff",
+                Price = 3.25f
+            };
+
             var req = WebServiceUtils.MakeStringContent<ProductJson>(p, Encoding.UTF8, "application/json");
             var res = this.WebServiceDriver.PatchWithResponse("/api/XML_JSON/Patch/1", "application/json", req, HttpStatusCode.OK);
             Assert.IsNotNull(res);

--- a/Framework/WebServiceUnitTests/WebServiceWithDriver.cs
+++ b/Framework/WebServiceUnitTests/WebServiceWithDriver.cs
@@ -7,6 +7,7 @@
 using Magenic.Maqs.BaseWebServiceTest;
 using Magenic.Maqs.Utilities.Helper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
@@ -67,6 +68,24 @@ namespace WebServiceTesterUnitTesting
             builder.Append("123");
 
             Assert.AreEqual(((StringBuilder)this.TestObject.Objects["1"]).ToString(), builder.ToString());
+        }
+
+        /// <summary>
+        /// Make we handle timeouts
+        /// </summary>
+        [TestMethod]
+        [TestCategory(TestCategories.WebService)]
+        [TestCategory(TestCategories.Utilities)]
+        [ExpectedException(typeof(TimeoutException))]
+        public void WebServiceTimeout()
+        {
+            var httpClient = this.GetHttpClient();
+            httpClient.Timeout = TimeSpan.FromMilliseconds(1);
+            this.WebServiceDriver = new WebServiceDriver(httpClient);
+
+            this.WebServiceDriver.Get("/api/String/1", "text/plain");
+
+            Assert.Fail("Get call should have timed out");
         }
     }
 }


### PR DESCRIPTION
Make sure the event firing driver logs for each type of service call.
Check of and note service call timeouts.

Fixes #646
Fixes #390   